### PR TITLE
适配深色主题模式

### DIFF
--- a/404.php
+++ b/404.php
@@ -9,8 +9,8 @@ $this->need('header.php');
             <p><?php _e('访问的页面已被转移或删除了, 要不要搜索看看: '); ?></p>
             <form method="post" action="<?php $this->options->siteUrl(); ?>" role="search">
                 <p>
-                    <label>
-                        <input type="text" name="s" class="text" autofocus />
+                    <label for="search-input-s3">
+                        <input id="search-input-s3" type="text" name="s" class="text" autofocus />
                     </label>
                 </p>
                 <p><button type="submit" class="submit btn btn-skin"><?php _e('搜索'); ?></button></p>

--- a/css/dark-mode.css
+++ b/css/dark-mode.css
@@ -1,0 +1,225 @@
+@charset "utf-8";
+
+:root {
+    --darkmode-background: #191a1a;
+    --darkmode-text: #a4a09b;
+    --darkmode-post-article-background: #242626;
+    --darkmode-dashed-color: #393b3c;
+    --darkmode-border-color: rgba(136, 131, 123, 0.13);
+    --darkmode-toggle-border-color: rgba(80, 80, 80, 1);
+    --darkmode-nav-active-backgroud-color: #303436;
+}
+
+
+[data-theme="dark"] {
+    color-scheme: dark;
+}
+
+/* 设置灰度 */
+[data-theme="dark"] {
+	-webkit-filter: grayscale(30%);
+	-moz-filter: grayscale(30%);
+	-ms-filter: grayscale(30%);
+	-o-filter: grayscale(30%);
+	filter: grayscale(30%);
+	filter: progid:DXImageTransform.Microsoft.BasicImage(grayscale=0.3);
+}
+
+[data-theme="dark"] body {
+    background-color: var(--darkmode-background);
+    color: var(--darkmode-text);
+}
+
+[data-theme="dark"] a {
+    color: var(--darkmode-text);
+}
+[data-theme="dark"] .tit a {
+    color: #e8e6e3;
+}
+
+[data-theme="dark"] .m-nav {
+    background-color: #3a3c3d;
+}
+[data-theme="dark"] .m-nav .nav .active a {
+    background-color: var(--darkmode-nav-active-backgroud-color);
+}
+[data-theme="dark"] .nav > li > a {
+    color: #cccccc;
+}
+[data-theme="dark"] .nav > li > a:not(.active):hover {
+    background-color: var(--darkmode-nav-active-backgroud-color);
+}
+
+[data-theme="dark"] .post-article {
+    background-color: var(--darkmode-post-article-background);
+}
+
+[data-theme="dark"] .category-cloud a {
+    color: #e8e6e3;
+}
+
+[data-theme="dark"] .row-border-dashed {
+    border-top-color: var(--darkmode-dashed-color);
+    border-bottom-color: var(--darkmode-dashed-color);
+}
+
+[data-theme="dark"] .article-content pre {
+    background-color: #1f2020;
+    border-color: var(--darkmode-border-color);
+}
+
+[data-theme="dark"] .card {
+background-color: var(--darkmode-post-article-background);
+  background-clip: border-box;
+  border-color: var(--darkmode-border-color);
+}
+
+[data-theme="dark"] .list-group-item {
+    background-color: var(--darkmode-post-article-background);
+    border-color: #37393a;
+    color: var(--darkmode-text);
+}
+
+[data-theme="dark"] .category a:hover {
+    color: var(--darkmode-text);
+}
+
+[data-theme="dark"] .category a {
+    border-bottom-color: #37393a;
+}
+
+[data-theme="dark"] .page-link {
+    color: var(--darkreader-text-0d6efd, #538cc0);
+    text-decoration-color: currentcolor;
+    background-color: var(--darkmode-background);
+    border-color: var(--darkmode-border-color);
+}
+[data-theme="dark"] .page-item.disabled .page-link {
+    background-color: var(--darkmode-post-article-background);
+    border-color: var(--darkmode-border-color);
+}
+
+[data-theme="dark"] .block {
+    background-color: #191a1a;
+    box-shadow: #404344 0px 5px 20px;
+}
+[data-theme="dark"] .badge-skin a {
+    color: #e8e6e3;
+}
+
+[data-theme="dark"] footer {
+    background-color: var(--darkreader-background-ffffff, #191a1a);
+}
+
+/* 评论样式 */
+[data-theme="dark"] .comments-block {
+    background-color: var(--darkreader-background-ffffff, #191a1a);
+    background-repeat: repeat;
+    background-image: none;
+    background-size: auto;
+    background-clip: border-box;
+    box-shadow: #404344 0px 5px 20px;
+    border-color: #3c3e3f;
+}
+[data-theme="dark"] .ui.badge {
+    background-color: #262829;
+    color: var(--darkmode-text);
+}
+
+/* 归档 */
+[data-theme="dark"] .archive-block {
+    background-color: var(--darkmode-post-article-background);
+}
+[data-theme="dark"] .archive-timeline .line .line-item {
+    border-color: #37393a;
+}
+[data-theme="dark"] .archive-timeline .archive-content::before {
+    background-color: #2d2f30;
+}
+[data-theme="dark"] .archive-timeline .timeline-big-dot::before {
+    background-color: #404344;
+}
+[data-theme="dark"] .archive-timeline .line .line-item::before {
+    background-color: #404344;
+}
+[data-theme="dark"] .comments-field input {
+    border-color: var(--darkmode-border-color);
+    background-color: var(--darkmode-post-article-background);
+}
+[data-theme="dark"] .comments-field textarea {
+    border-color: var(--darkmode-border-color);
+    background-color: var(--darkmode-post-article-background);
+}
+
+[data-theme="dark"] #back-to-top {
+    background-color: var(--darkmode-post-article-background);
+}
+
+/* 切换按钮 */
+#dark-mode-toggle {
+    cursor: pointer;
+    position: fixed;
+    right: 10px;
+    bottom: 140px;
+    z-index: 99;
+    color: white;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    border: #ccc 1px solid;
+    background: rgba(255, 255, 255, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+}
+
+#dark-mode-toggle:hover {
+    background-color: #eee;
+}
+
+[data-theme="dark"] #dark-mode-toggle {
+    background-color: rgba(33, 38, 45, 0.8);
+    border-color: var(--darkmode-toggle-border-color);
+}
+
+[data-theme="dark"] #dark-mode-toggle:hover {
+    background-color: #30363d;
+}
+
+#dark-mode-toggle i {
+    font-size: 20px;
+    color: #333;
+}
+
+[data-theme="dark"] #dark-mode-toggle i {
+    color: #c9d1d9;
+}
+
+[data-theme="dark"] #back-to-top {
+    border-color: var(--darkmode-toggle-border-color);
+}
+[data-theme="dark"] #switch_color {
+   border-color: var(--darkmode-toggle-border-color);
+}
+[data-theme="dark"] #switch_color .colorful {
+   border-color: var(--darkmode-toggle-border-color);
+}
+[data-theme="dark"] #switch_color .d-flex {
+    background-color: var(--darkmode-post-article-background);
+}
+[data-theme="dark"] #switch_color .border-light {
+    border-color: var(--darkmode-toggle-border-color) !important;
+}
+[data-theme="dark"] #switch_color .d-flex .m-1 {
+    box-shadow: #181a1b 0px 0px 30px inset;
+}
+[data-theme="dark"] #switch_color .m-1.active {
+    box-shadow: none;
+}
+
+@media screen and (max-width: 1100px) {
+    [data-theme="dark"] body {
+        background: #1a1a2e;
+    }
+}

--- a/css/main.css
+++ b/css/main.css
@@ -95,7 +95,7 @@ h6 tt, h6 code {
     width:auto;
 }
 
-#article-list .row-border-dashed {
+.row-border-dashed {
     margin-bottom: 0.875rem;
     border-top: 2px dashed #E7E7E7;
     border-bottom: 2px dashed #E7E7E7;
@@ -381,6 +381,9 @@ img.avatar {
 }
 
 /* 文章归档页时间轴 */
+.archive-block .archive-block{
+    background-color: #fff;
+}
 .archive-timeline .archive-content {
     margin-left: 2rem;
     position: relative;
@@ -469,7 +472,7 @@ img.avatar {
 .m-nav .nav > li > ul{text-align:left;position:absolute;top:52px;left:0;min-width:140px;z-index:10;display:none;}
 .m-nav .nav > li > ul > li > ul{text-align:left;position:absolute;top:0;left:100%;min-width:140px;z-index:10;display:none;}
 .m-nav .nav > li > ul > li{float:none;margin:0;position:relative}
-.m-nav .nav ul a{float:none;display:block;*min-width:100px;padding:5px 20px 4px;color:#eeeeee}
+.m-nav .nav ul a{float:none;display:block;min-width:100px;padding:5px 20px 4px;color:#eeeeee}
 .m-nav .nav ul a:hover,.m-nav .nav li li.current-menu-item a{color:#ffffff}
 .m-nav .nav li li a:hover,.m-nav .nav li li.current-menu-item a{background-color:#299982}
 .m-nav .nav li:hover a,.m-nav .nav li.current-menu-item a,.m-nav .nav li.current-menu-parent a,.m-nav .nav li.current_page_item a,.m-nav .nav li.current-post-ancestor a{background-color:#404040;}

--- a/css/skin-blue.css
+++ b/css/skin-blue.css
@@ -21,12 +21,12 @@ blockquote {
 
 .article-copyright a, .article-content a,
 .article-copyright a:hover, .article-content a:hover {
-    color: #00BFFF;
+    color: #00BFFF !important;
 }
 
 .btn-skin {
     border: 1px solid #00BFFF !important;
-    color: #00BFFF;
+    color: #00BFFF !important;
 }
 .btn-skin:hover {
     color: #fff !important;

--- a/css/skin-cyan.css
+++ b/css/skin-cyan.css
@@ -21,12 +21,12 @@ blockquote {
 
 .article-copyright a, .article-content a,
 .article-copyright a:hover, .article-content a:hover {
-    color: #00CDCD;
+    color: #00CDCD !important;
 }
 
 .btn-skin {
     border: 1px solid #00CDCD !important;
-    color: #00CDCD;
+    color: #00CDCD !important;
 }
 .btn-skin:hover {
     color: #fff !important;

--- a/css/skin-gray.css
+++ b/css/skin-gray.css
@@ -21,12 +21,12 @@ blockquote {
 
 .article-copyright a, .article-content a,
 .article-copyright a:hover, .article-content a:hover {
-    color: #BEBEBE;
+    color: #BEBEBE !important;
 }
 
 .btn-skin {
     border: 1px solid #BEBEBE !important;
-    color: #BEBEBE;
+    color: #BEBEBE !important;
 }
 .btn-skin:hover {
     color: #fff !important;

--- a/css/skin-green.css
+++ b/css/skin-green.css
@@ -21,12 +21,12 @@ blockquote {
 
 .article-copyright a, .article-content a,
 .article-copyright a:hover, .article-content a:hover {
-    color: #009a61;
+    color: #009a61 !important;
 }
 
 .btn-skin {
     border: 1px solid #16a085 !important;
-    color: #16a085;
+    color: #16a085 !important;
 }
 .btn-skin:hover {
     color: #fff !important;

--- a/css/skin-orange.css
+++ b/css/skin-orange.css
@@ -21,12 +21,12 @@ blockquote {
 
 .article-copyright a, .article-content a,
 .article-copyright a:hover, .article-content a:hover {
-    color: #FF8C00;
+    color: #FF8C00 !important;
 }
 
 .btn-skin {
     border: 1px solid #FF8C00 !important;
-    color: #FF8C00;
+    color: #FF8C00 !important;
 }
 .btn-skin:hover {
     color: #fff !important;

--- a/css/skin-purple.css
+++ b/css/skin-purple.css
@@ -21,12 +21,12 @@ blockquote {
 
 .article-copyright a, .article-content a,
 .article-copyright a:hover, .article-content a:hover {
-    color: #7D26CD;
+    color: #7D26CD !important;
 }
 
 .btn-skin {
     border: 1px solid #7D26CD !important;
-    color: #7D26CD;
+    color: #7D26CD !important;
 }
 .btn-skin:hover {
     color: #fff !important;

--- a/css/skin-red.css
+++ b/css/skin-red.css
@@ -21,12 +21,12 @@ blockquote {
 
 .article-copyright a, .article-content a,
 .article-copyright a:hover, .article-content a:hover {
-    color: #FF5555;
+    color: #FF5555 !important;
 }
 
 .btn-skin {
     border: 1px solid #FF5555 !important;
-    color: #FF5555;
+    color: #FF5555 !important;
 }
 .btn-skin:hover {
     color: #fff !important;

--- a/css/skin-yellow.css
+++ b/css/skin-yellow.css
@@ -21,12 +21,12 @@ blockquote {
 
 .article-copyright a, .article-content a,
 .article-copyright a:hover, .article-content a:hover {
-    color: #CDCD00;
+    color: #CDCD00 !important;
 }
 
 .btn-skin {
     border: 1px solid #CDCD00 !important;
-    color: #CDCD00;
+    color: #CDCD00 !important;
 }
 .btn-skin:hover {
     color: #fff !important;

--- a/footer.php
+++ b/footer.php
@@ -1,4 +1,9 @@
 <?php if (!defined('__TYPECHO_ROOT_DIR__')) exit(0); ?>
+<?php if ($this->options->allow_dark_mode !== '0') : ?>
+<div id="dark-mode-toggle" title="切换深色模式">
+    <i class="fa fa-moon-o"></i>
+</div>
+<?php endif; ?>
 <?php if ($this->options->allow_user_change_color) : ?>
 <div id="switch_color">
     <div class="colorful"></div>

--- a/functions.php
+++ b/functions.php
@@ -92,6 +92,10 @@ function themeConfig($form) {
         array(0=>_t('拒绝'),1=>_t('允许'),), '1', _t('是否允许用户切换主题色'),_t('浏览者可在右侧切换主题色（仅在该访者上生效）'));
     $form->addInput($allow_user_change_color);
 
+    $allow_dark_mode = new \Typecho\Widget\Helper\Form\Element\Radio('allow_dark_mode',
+        array(0=>_t('隐藏'),1=>_t('显示'),), '1', _t('是否显示深色模式切换按钮'),_t('浏览者可在右侧切换深色模式（仅在该访者上生效）'));
+    $form->addInput($allow_dark_mode);
+
     $showBlock = new \Typecho\Widget\Helper\Form\Element\Checkbox('ShowBlock', array(
         'HiddenHeaderGlobal' => _t('隐藏顶部头像'),
         'HiddenPostBottomBar' => _t('隐藏文章页上一篇和下一篇'),

--- a/header.php
+++ b/header.php
@@ -11,12 +11,22 @@
             'tag'       =>  _t('标签 %s 下的文章'),
             'author'    =>  _t('%s 发布的文章')
         ), '', ' - '); ?><?php $this->options->title(); ?></title>
+    <script>
+        // 在载入 css 文件之前设置主题, 确保在 DOM 渲染之前就设置好 data-theme="dark" 属性, 避免闪烁
+        (function() {
+            var theme = localStorage.getItem('green_grapes_theme');
+            if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            }
+        })();
+    </script>
     <link href="<?php $this->options->themeUrl('favicon.ico'); ?>" rel="shortcut icon"  type="image/x-icon">
     <!-- css -->
     <link rel="stylesheet" href="<?php $this->options->themeUrl('css/bootstrap.min.css'); ?>">
     <link rel="stylesheet" href="<?php $this->options->themeUrl('css/font-awesome.min.css'); ?>">
     <link rel="stylesheet" href="<?php $this->options->themeUrl('css/main.css'); ?>">
     <link rel="stylesheet" href="<?php $this->options->themeUrl('css/skin-'. get_theme_color() .'.css'); ?>">
+    <link rel="stylesheet" href="<?php $this->options->themeUrl('css/dark-mode.css'); ?>">
     <!-- 通过自有函数输出HTML头部信息 -->
     <?php if(class_exists('Snow_Plugin') && isset($this->options->plugins['activated']['Snow'])): ?>
     <style>
@@ -67,8 +77,8 @@
             </ul>
             <!-- 使用 .d-none .d-xl-block，在小于 lg 尺寸(1100px)的屏幕上隐藏 -->
             <form class="d-flex d-none d-xl-flex" method="post" action="<?php $this->options->siteUrl(); ?>" role="search">
-                <label for="s" class="me-2">
-                    <input class="form-control" name="s" placeholder="搜索关键词..." type="text" />
+                <label for="search-input-s2" class="me-2">
+                    <input id="search-input-s2" class="form-control" name="s" placeholder="搜索关键词..." type="text" />
                 </label>
                 <button class="btn btn-secondary"><i class="fa fa-search"></i> 查找</button>
             </form>

--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
  *
  * @package GreenGrapes
  * @author hongweipeng
- * @version 3.0.1
+ * @version 4.0.0
  * @link https://github.com/hongweipeng/GreenGrapes
  */
 if (!defined('__TYPECHO_ROOT_DIR__')) exit(0);

--- a/js/home.js
+++ b/js/home.js
@@ -160,7 +160,7 @@ $(document).ready(function () {
 
     if ($('#tag-cloud-tags').length) {
         TagCanvas.Start('tag-cloud-tags', '', {
-            textColour: '#000000',
+            textColour: '#777777',
             outlineColour: $('.skin-bg').css('background-color'),
             outlineThickness: 1,
             maxSpeed: 0.03,
@@ -170,10 +170,53 @@ $(document).ready(function () {
     }
     
     // 切换主题
+    var $switchColor = $('#switch_color');
+    var $colorPanel = $switchColor.find('.d-flex');
+    var hideTimer = null;
+    
+    $switchColor.add($colorPanel).on('mouseenter', function() {
+        clearTimeout(hideTimer);
+        $switchColor.addClass('show');
+    });
+    
+    $switchColor.add($colorPanel).on('mouseleave', function() {
+        hideTimer = setTimeout(function() {
+            $switchColor.removeClass('show');
+        }, 200);
+    });
+    
     $('#switch_color .flex-fill').click(function(e) {
         var obj = $(this);
         $.cookie('green_grapes_color', obj.data('color'));
         location.reload();
+    });
+
+    // 深色模式切换
+    function updateDarkModeIcon() {
+        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        var icon = $('#dark-mode-toggle i');
+        if (isDark) {
+            icon.removeClass('fa-moon-o').addClass('fa-lightbulb-o');
+        } else {
+            icon.removeClass('fa-lightbulb-o').addClass('fa-moon-o');
+        }
+    }
+
+    updateDarkModeIcon();
+
+    $('#dark-mode-toggle').click(function() {
+        var currentTheme = document.documentElement.getAttribute('data-theme');
+        var newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        
+        if (newTheme === 'dark') {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            localStorage.setItem('green_grapes_theme', 'dark');
+        } else {
+            document.documentElement.removeAttribute('data-theme');
+            localStorage.setItem('green_grapes_theme', 'light');
+        }
+        
+        updateDarkModeIcon();
     });
 });
 })(jQuery);

--- a/page-archive-timeline.php
+++ b/page-archive-timeline.php
@@ -18,7 +18,7 @@ $this->need('header.php');
             ?>
             <div class="col-md-8 archive-timeline">
                 <div class="alert alert-info">共有 <?php _e($total); ?> 篇文章</div>
-                <div class="bg-white pt-1 pb-1">
+                <div class="post-article pt-1 pb-1">
                     <div class="archive-content">
                         <?php $groupYear = ''; ?>
                         <?php while ($recent->next()): ?>

--- a/page-tag-cloud.php
+++ b/page-tag-cloud.php
@@ -11,7 +11,7 @@ $this->need('header.php');
     <div id="m-container" class="container">
         <div class="row">
             <div class="col-md-12">
-                <div class="bg-white text-center">
+                <div class="post-article text-center">
                     <canvas height="700" width="700" id="tag-cloud-tags">
                         <p>标签云</p>
                         <?php $this->widget('\Widget\Metas\Category\Rows')->listCategories('wrapClass=widget-list'); ?>


### PR DESCRIPTION
作为一个长期依赖深色模式的用户，我深知那种「深夜码字不刺眼」的体验有多重要。所以这次给博客主题做适配时，深色模式成了我的优先项。
不只是简单地把背景变黑、文字变白——我花了不少时间调整对比度、优化代码高亮的配色、确保图片在暗色背景下不会突兀。最终效果我自己挺满意的，现在无论白天黑夜，阅读体验都能保持一致。
如果你也是深色模式爱好者，应该会喜欢这个小改动。